### PR TITLE
Feature/display html

### DIFF
--- a/src/components/Article/ArticleCell.js
+++ b/src/components/Article/ArticleCell.js
@@ -1,10 +1,9 @@
 import React, { lazy } from 'react';
 import { Container, Row, Col} from 'react-bootstrap'
-import ArticleCellFigure from './ArticleCellFigure'
 import ArticleCellOutput from './ArticleCellOutput'
 import ArticleCellContent from './ArticleCellContent'
 import ArticleCellSourceCode from './ArticleCellSourceCode'
-
+import ArticleCellFigure from './ArticleCellFigure'
 import {
   ModuleStack, ModuleTextObject, ModuleObject,
   ModuleQuote, BootstrapColumLayout
@@ -44,7 +43,7 @@ const ArticleCell = ({
       </Container>
     )
   }
-  if (cellModule === ModuleObject) {
+  if (!figure && cellModule === ModuleObject) {
     return (
       <Container>
         <Row>
@@ -70,14 +69,21 @@ const ArticleCell = ({
   }
 
   if (type === 'markdown') {
+    if (figure) {
+      return (
+        <ArticleCellFigure
+          metadata={metadata}
+          figure={figure}
+          figureColumnLayout={cellObjectBootstrapColumnLayout}
+        >
+          <ArticleCellContent hideNum={!!figure} layer={layer} content={content} idx={idx} num={num} />
+        </ArticleCellFigure>
+      )
+    }
     return (
       <Container>
         <Row>
           <Col {... cellBootstrapColumnLayout}>
-            { figure ? <ArticleCellFigure
-              metadata={metadata}
-              figure={figure}
-            /> : null}
             <ArticleCellContent hideNum={!!figure} layer={layer} content={content} idx={idx} num={num} />
           </Col>
         </Row>
@@ -85,33 +91,28 @@ const ArticleCell = ({
     )
   }
   if (type === 'code') {
+    if (figure) {
+      return (
+        <ArticleCellFigure
+          metadata={metadata}
+          outputs={outputs}
+          figure={figure}
+          sourceCode={<ArticleCellSourceCode toggleVisibility content={content} language="python"/>}
+        ></ArticleCellFigure>
+      )
+    }
     return (
       <Container>
         <Row>
           <Col {... cellBootstrapColumnLayout}>
-            { figure
-              ? (
-                <>
-                <ArticleCellFigure
-                  metadata={metadata}
-                  figure={figure}
-                  source={content}
-                  outputs={outputs}
-                />
-                <ArticleCellSourceCode toggleVisibility content={content} language="python"/>
-                </>
-              )
-              : (
-                <div className="ArticleCellContent" id={`P${idx}`}>
-                  <div className="ArticleCellContent_num"></div>
-                  <ArticleCellSourceCode visible content={content} language="python" />
-                  {outputs.length
-                    ? outputs.map((output,i) => <ArticleCellOutput output={output} key={i} />)
-                    : <div className="ArticleCellSourceCode_no_output">no output</div>
-                  }
-                </div>
-              )
-            }
+            <div className="ArticleCellContent" id={`P${idx}`}>
+              <div className="ArticleCellContent_num"></div>
+              <ArticleCellSourceCode visible content={content} language="python" />
+              {outputs.length
+                ? outputs.map((output,i) => <ArticleCellOutput output={output} key={i} />)
+                : <div className="ArticleCellSourceCode_no_output">no output</div>
+              }
+            </div>
           </Col>
         </Row>
       </Container>

--- a/src/components/Article/ArticleCellFigure.js
+++ b/src/components/Article/ArticleCellFigure.js
@@ -21,7 +21,7 @@ const ArticleCellFigure = ({ figure, metadata={}, outputs=[], sourceCode, childr
   }, BootstrapColumLayout)
 
   return (
-    <div className="ArticleCellFigure small">
+    <div className="ArticleCellFigure">
     <Container fluid={metadata.tags.includes('full-width')}>
       <Row>
         <Col {...figureColumnLayout}>
@@ -41,7 +41,7 @@ const ArticleCellFigure = ({ figure, metadata={}, outputs=[], sourceCode, childr
       </Row>
     </Container>
     <Container>
-      <Row>
+      <Row className="small">
         <Col {...BootstrapColumLayout}>
         {sourceCode}
         <ArticleFigure figure={figure}><p dangerouslySetInnerHTML={{

--- a/src/components/Article/ArticleCellFigure.js
+++ b/src/components/Article/ArticleCellFigure.js
@@ -22,7 +22,7 @@ const ArticleCellFigure = ({ figure, metadata={}, outputs=[], sourceCode, childr
 
   return (
     <div className="ArticleCellFigure">
-    <Container fluid={metadata.tags.includes('full-width')}>
+    <Container fluid={metadata.tags && metadata.tags.includes('full-width')}>
       <Row>
         <Col {...figureColumnLayout}>
           <div >

--- a/src/components/Article/ArticleCellFigure.js
+++ b/src/components/Article/ArticleCellFigure.js
@@ -2,9 +2,10 @@ import React from 'react'
 import ArticleCellOutput from './ArticleCellOutput'
 import ArticleFigure from './ArticleFigure'
 import { markdownParser } from '../../logic/ipynb'
+import {BootstrapColumLayout} from '../../constants'
+import { Container, Row, Col} from 'react-bootstrap'
 
-
-const ArticleCellFigure = ({ figure, outputs=[] }) => {
+const ArticleCellFigure = ({ figure, metadata={}, outputs=[], sourceCode, children }) => {
   const captions = outputs.reduce((acc, output) => {
     if (output.metadata && Array.isArray(output.metadata?.jdh?.object?.source)) {
       acc.push(markdownParser.render(output.metadata.jdh.object.source.join('\n')))
@@ -12,20 +13,43 @@ const ArticleCellFigure = ({ figure, outputs=[] }) => {
     return acc
   }, [])
 
+  const figureColumnLayout = outputs.reduce((acc, output) => {
+    if (output.metadata && output.metadata.jdh?.object?.bootstrapColumLayout) {
+      acc = {...output.metadata.jdh?.object?.bootstrapColumLayout }
+    }
+    return acc
+  }, BootstrapColumLayout)
+
   return (
-    <div className="ArticleCellFigure">
-      <div className="anchor" id={figure.ref} />
-    {!outputs.length ? (
-      <div className="ArticleCellFigure_no_output">
-      no output
-      </div>
-    ): null}
-    {outputs.map((output,i) => (
-      <ArticleCellOutput hideLabel output={output} key={i} />
-    ))}
-    <ArticleFigure figure={figure}><p dangerouslySetInnerHTML={{
-      __html: captions.join('<br />'),
-    }} /></ArticleFigure>
+    <div className="ArticleCellFigure small">
+    <Container fluid={metadata.tags.includes('full-width')}>
+      <Row>
+        <Col {...figureColumnLayout}>
+          <div >
+            <div className="anchor" id={figure.ref} />
+          {!outputs.length ? (
+            <div className="ArticleCellFigure_no_output">
+            no output
+            </div>
+          ): null}
+          {outputs.map((output,i) => (
+            <ArticleCellOutput hideLabel output={output} key={i} />
+          ))}
+          </div>
+          {children}
+        </Col>
+      </Row>
+    </Container>
+    <Container>
+      <Row>
+        <Col {...BootstrapColumLayout}>
+        {sourceCode}
+        <ArticleFigure figure={figure}><p dangerouslySetInnerHTML={{
+          __html: captions.join('<br />'),
+        }} /></ArticleFigure>
+        </Col>
+      </Row>
+    </Container>
     </div>
   )
 }

--- a/src/components/Article/ArticleCellOutput.js
+++ b/src/components/Article/ArticleCellOutput.js
@@ -19,7 +19,7 @@ const ArticleCellOutput = ({ output, hideLabel=false }) => {
     )
   }
   if (output.output_type === 'display_data' && output.data['text/html']) {
-    return (<div className={`ArticleCellOutput withHTML ${outputTypeClassName}`} dangerouslySetInnerHTML={{
+    return (<div className={`ArticleCellOutput withHTML mb-3 ${outputTypeClassName}`} dangerouslySetInnerHTML={{
       __html: getOutput(output.data['text/html'])
     }} />)
   }

--- a/src/components/Article/ArticleCellOutput.js
+++ b/src/components/Article/ArticleCellOutput.js
@@ -18,6 +18,11 @@ const ArticleCellOutput = ({ output, hideLabel=false }) => {
       }}/>
     )
   }
+  if (output.output_type === 'display_data' && output.data['text/html']) {
+    return (<div className={`ArticleCellOutput ${outputTypeClassName}`} dangerouslySetInnerHTML={{
+      __html: getOutput(output.data['text/html'])
+    }} />)
+  }
 
   return (
     <blockquote className={`${outputTypeClassName}`}>

--- a/src/components/Article/ArticleCellOutput.js
+++ b/src/components/Article/ArticleCellOutput.js
@@ -19,7 +19,7 @@ const ArticleCellOutput = ({ output, hideLabel=false }) => {
     )
   }
   if (output.output_type === 'display_data' && output.data['text/html']) {
-    return (<div className={`ArticleCellOutput ${outputTypeClassName}`} dangerouslySetInnerHTML={{
+    return (<div className={`ArticleCellOutput withHTML ${outputTypeClassName}`} dangerouslySetInnerHTML={{
       __html: getOutput(output.data['text/html'])
     }} />)
   }

--- a/src/components/Article/ArticleCellSourceCode.js
+++ b/src/components/Article/ArticleCellSourceCode.js
@@ -6,7 +6,7 @@ import hljs from "highlight.js"; // import hljs library
 import 'highlight.js/styles/dracula.css';
 
 
-const ArticleCellSourceCode = ({ content, language, toggleVisibility, visible }) => {
+const ArticleCellSourceCode = ({ content, language, toggleVisibility, visible, right }) => {
   const [isSourceCodeVisible, setIsSourceCodeVisible] = useState(visible)
   const { t } = useTranslation()
   const highlighted = language
@@ -14,10 +14,10 @@ const ArticleCellSourceCode = ({ content, language, toggleVisibility, visible })
       : hljs.highlightAuto(content);
 
   return (
-    <div className="ArticleCellSourceCode" >
+    <div className="ArticleCellSourceCode " >
       {toggleVisibility
         ? (
-          <>
+          <div className={right?'text-right':''}>
           <Button size="sm" variant="outline-secondary" onClick={() => setIsSourceCodeVisible(!isSourceCodeVisible)}>
             {isSourceCodeVisible? <EyeOff size="16"/> : <Eye size="16"/>}
             <span className="ml-2">{t(isSourceCodeVisible
@@ -25,7 +25,7 @@ const ArticleCellSourceCode = ({ content, language, toggleVisibility, visible })
               : 'actions.showsourceCode'
             )}</span>
           </Button>
-          </>
+          </div>
         )
         : null
       }

--- a/src/styles/article.scss
+++ b/src/styles/article.scss
@@ -210,6 +210,10 @@
   border: 0;
   border-top: 1px solid var(--gray-400);
   border-bottom: 1px solid var(--gray-400);
+  background-color: var(--gray-100);
+  caption{
+    display: none;
+  }
 
   tbody tr:nth-of-type(odd) {
     background-color: var(--gray-200);

--- a/src/styles/article.scss
+++ b/src/styles/article.scss
@@ -198,6 +198,20 @@
   }
 }
 
+.ArticleCellOutput table{
+  width: 100%;
+  font-size: .8em;
+  // .table-striped
+  border-top: 1px solid var(--gray-400);
+  border-bottom: 1px solid var(--gray-400);
+
+  tbody tr:nth-of-type(odd) {
+    background-color: var(--gray-200);
+  }
+  td, th{
+    padding: var(--spacer-2);
+  }
+}
 .ArticleCellOutput_display_data img{
   max-width: 100%;
 }

--- a/src/styles/article.scss
+++ b/src/styles/article.scss
@@ -198,10 +198,16 @@
   }
 }
 
-.ArticleCellOutput table{
+.ArticleCellOutput.withHTML {
   width: 100%;
+  overflow: scroll;
+  max-width: 100%;
+}
+
+.ArticleCellOutput table{
   font-size: .8em;
   // .table-striped
+  border: 0;
   border-top: 1px solid var(--gray-400);
   border-bottom: 1px solid var(--gray-400);
 
@@ -211,6 +217,9 @@
   td, th{
     padding: var(--spacer-2);
   }
+}
+.ArticleCellOutput_display_data {
+  background-color: var(--gray-200);
 }
 .ArticleCellOutput_display_data img{
   max-width: 100%;
@@ -309,4 +318,19 @@
   z-index: 2;
   top: 0;
   pointer-events: none;
+}
+
+.ArticleFigure{
+  min-height: 50px;
+  margin-top:  var(--spacer-3);
+}
+
+.ArticleFigure_figcaption_num {
+  position: absolute;
+  left: -140px;
+  width: 140px;
+  text-align: right;
+  padding-right: var(--spacer-3);
+  font-family: var(--font-family-monospace);
+  font-weight: bold;
 }

--- a/src/styles/article.scss
+++ b/src/styles/article.scss
@@ -222,9 +222,9 @@
     padding: var(--spacer-2);
   }
 }
-.ArticleCellOutput_display_data {
-  background-color: var(--gray-200);
-}
+// .ArticleCellOutput_display_data {
+//   background-color: var(--gray-200);
+// }
 .ArticleCellOutput_display_data img{
   max-width: 100%;
 }

--- a/src/styles/module.scss
+++ b/src/styles/module.scss
@@ -63,8 +63,7 @@
   pointer-events:all;
 }
 
-.ImageWrapper_figcaption_num,
-.ArticleFigure_figcaption_num {
+.ImageWrapper_figcaption_num {
   position: absolute;
   left: -100px;
   width: 100px;

--- a/src/styles/module.scss
+++ b/src/styles/module.scss
@@ -66,8 +66,10 @@
 .ImageWrapper_figcaption_num,
 .ArticleFigure_figcaption_num {
   position: absolute;
-  left: var(--negative-spacer-6);
-  width: var(--spacer-6);
+  left: -100px;
+  width: 100px;
+  text-align: right;
+  padding-right: var(--spacer-3);
   font-family: var(--font-family-monospace);
   font-weight: bold;
 }

--- a/src/translations.json
+++ b/src/translations.json
@@ -156,7 +156,7 @@
         "instance-abstract": "<b>Abstract</b>"
       },
       "numbers": {
-        "figure": "Fig. {{ n }}",
+        "figure": "Figure {{ n }}",
         "table": "Table {{ n }}",
         "yExponent": "Power scale exponent (y axis): <b>{{n}}</b>",
         "errors": "{{count}} errors",


### PR DESCRIPTION
- update labels fr figure and tables in translations, fix #91
- introduce tables, fix #87 
- add `full-width` tag support to have a fluid bootstrap Container
- enable bootstrap column layout ony on display_data content, this way both figure caption and source code stay in line with the article content