### PR TITLE
fix #413

### DIFF
--- a/src/components/Article/ArticleCellOutputs.js
+++ b/src/components/Article/ArticleCellOutputs.js
@@ -15,12 +15,19 @@ const ArticleCellOutputs = ({
         return acc.concat(output.data['application/javascript'])
       } else if (Array.isArray(output.data['text/html'])) {
         // view if there are any candidate
-        if (output.data['text/html'].some(d => d.indexOf('/script>'))) {
+
+        if (output.data['text/html'].some(d => d.indexOf('/script>') !== -1)) {
           // we should alert somehow.
-          const htmlScript = output.data['text/html'].join('').match(/(?<=(\x3Cscript[^>]*>))([\s\S]*?)\x3C\/script>/m)
+          // eslint-disable-next-line
+          const htmlScript = output.data['text/html'].join('')
+            .match(/\x3Cscript[^>]*>([\s\S]*?)\x3C\/script>/m)
           if (htmlScript) {
+            if (htmlScript[1].indexOf('\x3Cscript') !== -1) {
+              console.warn('multiple scripts in text/html, skipping.')
+              return acc
+            }
             console.debug('[ArticleCellOutputs] cellIdx:', cellIdx, 'contains:', htmlScript[2])
-            return acc.concat(htmlScript[2])
+            return acc.concat(htmlScript[1])
           }
         }
         // // eslint-disable-next-line


### PR DESCRIPTION
On safari, look behind doesnt work in regex and it is not possible to try catch (syntaxError!)