### PR TITLE
Fix/scroll into view

### DIFF
--- a/src/components/Article/ArticleCell.js
+++ b/src/components/Article/ArticleCell.js
@@ -17,9 +17,7 @@ import {
   ArticleCellContainerClassNames,
 } from '../../constants'
 
-const ArticleCellVisualisation = lazy(() =>
-  import('./ArticleCellVisualisation')
-)
+const ArticleCellVisualisation = lazy(() => import('./ArticleCellVisualisation'))
 const ArticleCellTextObject = lazy(() => import('./ArticleCellTextObject'))
 const ArticleCellObject = lazy(() => import('./ArticleCellObject'))
 
@@ -40,9 +38,9 @@ const ArticleCell = ({
   headingLevel = 0, // if isHeading, set this to its ArticleHeading.level value
   isJavascriptTrusted = false,
   onNumClick,
+  windowHeight = 0,
 }) => {
-  let cellBootstrapColumnLayout =
-    metadata.jdh?.text?.bootstrapColumLayout || BootstrapColumLayout
+  let cellBootstrapColumnLayout = metadata.jdh?.text?.bootstrapColumLayout || BootstrapColumLayout
   // we override or set the former layout if it appears in narrative-step
   if (isNarrativeStep) {
     cellBootstrapColumnLayout = BootstrapNarrativeStepColumnLayout
@@ -56,28 +54,18 @@ const ArticleCell = ({
   const cellModule = metadata.jdh?.module
 
   const containerClassNames = (metadata.tags ?? []).filter((d) =>
-    ArticleCellContainerClassNames.includes(d)
+    ArticleCellContainerClassNames.includes(d),
   )
 
   if (cellModule === ModuleStack) {
-    return (
-      <ArticleCellVisualisation
-        metadata={metadata}
-        progress={progress}
-        active={active}
-      />
-    )
+    return <ArticleCellVisualisation metadata={metadata} progress={progress} active={active} />
   }
   if (cellModule === ModuleTextObject) {
     return (
       <Container className={containerClassNames.join(' ')}>
         <Row>
           <Col {...cellBootstrapColumnLayout}>
-            <ArticleCellTextObject
-              metadata={metadata}
-              progress={progress}
-              active={active}
-            />
+            <ArticleCellTextObject metadata={metadata} progress={progress} active={active} />
           </Col>
           <Col {...cellObjectBootstrapColumnLayout}>
             <ArticleCellObject
@@ -111,7 +99,7 @@ const ArticleCell = ({
     return (
       <Container className={containerClassNames.join(' ')}>
         <Row>
-          <Col className='ArticleCellQuote' {...BootstrapQuoteColumLayout}>
+          <Col className="ArticleCellQuote" {...BootstrapQuoteColumLayout}>
             <ArticleCellContent
               onNumClick={onNumClick}
               layer={layer}
@@ -136,6 +124,8 @@ const ArticleCell = ({
           isJavascriptTrusted={isJavascriptTrusted}
           isNarrativeStep={isNarrativeStep}
           containerClassName={containerClassNames.join(' ')}
+          windowHeight={windowHeight}
+          active={active}
         >
           <ArticleCellContent
             onNumClick={onNumClick}
@@ -175,12 +165,10 @@ const ArticleCell = ({
           isNarrativeStep={isNarrativeStep}
           figureColumnLayout={cellObjectBootstrapColumnLayout}
           isJavascriptTrusted={isJavascriptTrusted}
+          windowHeight={windowHeight}
+          active={active}
           sourceCode={
-            <ArticleCellSourceCode
-              toggleVisibility
-              content={content}
-              language='python'
-            />
+            <ArticleCellSourceCode toggleVisibility content={content} language="python" />
           }
           containerClassName={containerClassNames.join(' ')}
         ></ArticleCellFigure>
@@ -191,13 +179,9 @@ const ArticleCell = ({
       <Container className={containerClassNames.join(' ')}>
         <Row>
           <Col {...cellBootstrapColumnLayout}>
-            <div className='ArticleCellContent'>
-              <div className='ArticleCellContent_num'></div>
-              <ArticleCellSourceCode
-                visible
-                content={content}
-                language='python'
-              />
+            <div className="ArticleCellContent">
+              <div className="ArticleCellContent_num"></div>
+              <ArticleCellSourceCode visible content={content} language="python" />
               <ArticleCellOutputs
                 isJavascriptTrusted={isJavascriptTrusted}
                 cellIdx={idx}
@@ -213,10 +197,7 @@ const ArticleCell = ({
 }
 
 export default React.memo(ArticleCell, (prevProps, nextProps) => {
-  if (
-    prevProps.memoid === nextProps.memoid ||
-    prevProps.active === nextProps.active
-  ) {
+  if (prevProps.memoid === nextProps.memoid || prevProps.active === nextProps.active) {
     return true // props are equal
   }
   return false // props are not equal -> update the component

--- a/src/components/Article/ArticleCellFigure.js
+++ b/src/components/Article/ArticleCellFigure.js
@@ -15,7 +15,6 @@ const ArticleCellFigure = ({
   figureColumnLayout,
   children,
   containerClassName,
-  active,
   windowHeight = 100,
 }) => {
   const tags = Array.isArray(metadata.tags) ? metadata.tags : []
@@ -72,7 +71,14 @@ const ArticleCellFigure = ({
     }
   }
 
-  console.debug('[ArticleCellFigure] active, idx:', figure.idx, active)
+  console.debug(
+    '[ArticleCellFigure] \n - idx:',
+    figure.idx,
+    '\n - aspectRatio:',
+    aspectRatio,
+    '\n - tags:',
+    tags,
+  )
 
   return (
     <div className={`ArticleCellFigure ${aspectRatio ? 'with-aspect-ratio' : ''}`}>
@@ -96,7 +102,7 @@ const ArticleCellFigure = ({
                 isJavascriptTrusted={isJavascriptTrusted}
                 cellIdx={figure.idx}
                 outputs={outputs}
-                height={figureHeight}
+                height={!isNaN(aspectRatio) ? 'auto' : figureHeight}
               />
             </figure>
             {children}

--- a/src/components/Article/ArticleCellFigure.js
+++ b/src/components/Article/ArticleCellFigure.js
@@ -30,7 +30,7 @@ const ArticleCellFigure = ({
     if (!ratio) {
       return acc
     }
-    return ratio[1] / (ratio[2] || 1)
+    return ratio[2] / (ratio[1] || 1)
   }, undefined)
   // get figure height if any has been specified with the tags. Otherwise default is windowHeight * .5
   let figureHeight = tags.reduce((acc, tag) => {

--- a/src/components/Article/ArticleCellFigure.js
+++ b/src/components/Article/ArticleCellFigure.js
@@ -14,17 +14,29 @@ const ArticleCellFigure = ({
   figureColumnLayout,
   children,
   containerClassName,
+  active,
+  windowHeight = 100,
 }) => {
-  const isFluidContainer =
-    figure.isCover || (metadata.tags && metadata.tags.includes('full-width'))
+  const tags = Array.isArray(metadata.tags) ? metadata.tags : []
+  const isFluidContainer = figure.isCover || tags.includes('full-width')
+  // calculate optimal figure height and allow special h-tags. Default is windowHeight * .5
+  let figureHeight = tags.reduce((acc, tag) => {
+    const m = tag.match(/^h-(\d+)(px)?$/) // h-50 h-100 or h-100px
+    if (!m) {
+      return acc
+    }
+    if (m[2]) {
+      // e.g `h-500px`
+      return [m[1], m[2]].join('')
+    }
+    // e.g `h-50` `h-100` or `h-25` or `h-200`
+    return Math.max(200, (windowHeight * m[1]) / 100)
+  }, windowHeight * 0.5)
+  figureHeight = Math.max(200, figureHeight)
+
   const captions = outputs.reduce((acc, output) => {
-    if (
-      output.metadata &&
-      Array.isArray(output.metadata?.jdh?.object?.source)
-    ) {
-      acc.push(
-        markdownParser.render(output.metadata.jdh.object.source.join('\n'))
-      )
+    if (output.metadata && Array.isArray(output.metadata?.jdh?.object?.source)) {
+      acc.push(markdownParser.render(output.metadata.jdh.object.source.join('\n')))
     }
     return acc
   }, [])
@@ -36,10 +48,7 @@ const ArticleCellFigure = ({
   let columnLayout =
     figureColumnLayout ??
     outputs.reduce((acc, output) => {
-      if (
-        output.metadata &&
-        output.metadata.jdh?.object?.bootstrapColumLayout
-      ) {
+      if (output.metadata && output.metadata.jdh?.object?.bootstrapColumLayout) {
         acc = { acc, ...output.metadata.jdh?.object?.bootstrapColumLayout }
       }
       return acc
@@ -52,18 +61,21 @@ const ArticleCellFigure = ({
     }
   }
 
+  console.debug('[ArticleCellFigure] active, idx:', figure.idx, active)
+
   return (
-    <div className='ArticleCellFigure'>
+    <div className="ArticleCellFigure">
       <Container className={containerClassName} fluid={isFluidContainer}>
         <Row>
           <Col {...columnLayout}>
             <div>
-              <div className='anchor' id={figure.ref} />
+              <div className="anchor" id={figure.ref} />
               <ArticleCellOutputs
                 hideLabel
                 isJavascriptTrusted={isJavascriptTrusted}
                 cellIdx={figure.idx}
                 outputs={outputs}
+                height={figureHeight}
               />
             </div>
             {children}
@@ -72,7 +84,7 @@ const ArticleCellFigure = ({
       </Container>
       {figure.isCover ? null : (
         <Container>
-          <Row className='small'>
+          <Row className="small">
             <Col {...BootstrapColumLayout}>
               {sourceCode}
               <ArticleFigure figure={figure}>

--- a/src/components/Article/ArticleCellOutput.js
+++ b/src/components/Article/ArticleCellOutput.js
@@ -38,6 +38,9 @@ const ArticleCellOutput = ({
         }
     : {}
 
+  if (output.name !== 'stdout' && !output?.data) {
+    console.warn('Output data is undefined for cell:', cellIdx, 'output:', output)
+  }
   if (output.output_type === 'display_data' && output.data['text/markdown']) {
     return (
       <div

--- a/src/components/Article/ArticleCellOutput.js
+++ b/src/components/Article/ArticleCellOutput.js
@@ -17,16 +17,19 @@ const ArticleCellOutput = ({
 }) => {
   const outputTypeClassName = `ArticleCellOutput_${output.output_type}`
   const { t } = useTranslation()
-  let style = !isNaN(height)
+  const style = !isNaN(height)
     ? !isNaN(width)
       ? {
           // constrain output to this size. used for images.
           width,
           height,
+          objectFit: 'contain',
+          display: 'block',
+          margin: '0 auto',
         }
       : {
           height,
-          objectFit: 'scale-down',
+          objectFit: 'contain',
           display: 'block',
           margin: '0 auto',
           // background: '#0000000c',
@@ -34,7 +37,6 @@ const ArticleCellOutput = ({
           // backgroundClip: 'content-box',
         }
     : {}
-  style = null
 
   if (output.output_type === 'display_data' && output.data['text/markdown']) {
     return (

--- a/src/components/Article/ArticleCellOutput.js
+++ b/src/components/Article/ArticleCellOutput.js
@@ -71,7 +71,7 @@ const ArticleCellOutput = ({
     )
   }
 
-  const encodedImages = Object.keys(output.data)
+  const encodedImages = Object.keys(output?.data ?? {})
     .filter((mimetype) => mimetype.indexOf('image/') === 0)
     .map((mimetype) => `data:${mimetype};base64,${output.data[mimetype]}`)
 

--- a/src/components/Article/ArticleCellOutput.js
+++ b/src/components/Article/ArticleCellOutput.js
@@ -1,32 +1,55 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import {markdownParser} from '../../logic/ipynb'
+import { markdownParser } from '../../logic/ipynb'
 import ArticleCellOutputPlugin from './ArticleCellOutputPlugin'
 
 const getOutput = (output) => {
-  return Array.isArray(output)
-    ? output.join(' ')
-    : output
+  return Array.isArray(output) ? output.join(' ') : output
 }
 
-const ArticleCellOutput = ({ output, height, width, hideLabel=false, isJavascriptTrusted=false, cellIdx=-1 }) => {
-  const outputTypeClassName= `ArticleCellOutput_${output.output_type}`
+const ArticleCellOutput = ({
+  output,
+  height,
+  width,
+  hideLabel = false,
+  isJavascriptTrusted = false,
+  cellIdx = -1,
+}) => {
+  const outputTypeClassName = `ArticleCellOutput_${output.output_type}`
   const { t } = useTranslation()
-  const style = !isNaN(width) && !isNaN(height) ? {
-    // constrain output to this size. used for images.
-    width,
-    height,
-  } : {}
+  let style = !isNaN(height)
+    ? !isNaN(width)
+      ? {
+          // constrain output to this size. used for images.
+          width,
+          height,
+        }
+      : {
+          height,
+          objectFit: 'scale-down',
+          display: 'block',
+          margin: '0 auto',
+          // background: '#0000000c',
+          // border: '2px solid #0000000c',
+          // backgroundClip: 'content-box',
+        }
+    : {}
+  style = null
 
-  if(output.output_type === 'display_data' && output.data['text/markdown']) {
+  if (output.output_type === 'display_data' && output.data['text/markdown']) {
     return (
-      <div className={`ArticleCellOutput ${outputTypeClassName}`} style={style} dangerouslySetInnerHTML={{
-        __html: markdownParser.render(getOutput(output.data['text/markdown']))
-      }}/>
+      <div
+        className={`ArticleCellOutput ${outputTypeClassName}`}
+        // style={style}
+        dangerouslySetInnerHTML={{
+          __html: markdownParser.render(getOutput(output.data['text/markdown'])),
+        }}
+      />
     )
   }
   if (['execute_result', 'display_data'].includes(output.output_type) && output.data['text/html']) {
-    if (isJavascriptTrusted) { // use DOM directly to handle this
+    if (isJavascriptTrusted) {
+      // use DOM directly to handle this
       return (
         <ArticleCellOutputPlugin
           cellIdx={cellIdx}
@@ -35,34 +58,37 @@ const ArticleCellOutput = ({ output, height, width, hideLabel=false, isJavascrip
       )
     }
     return (
-      <div className={`ArticleCellOutput withHTML mb-3 ${outputTypeClassName} ${isJavascriptTrusted ? 'withJS' : 'noJS'}`}
-        style={style}
+      <div
+        className={`ArticleCellOutput withHTML mb-3 ${outputTypeClassName} ${
+          isJavascriptTrusted ? 'withJS' : 'noJS'
+        }`}
         dangerouslySetInnerHTML={{
-        __html: getOutput(output.data['text/html'])
+          __html: getOutput(output.data['text/html']),
         }}
       />
     )
   }
 
+  const encodedImages = Object.keys(output.data)
+    .filter((mimetype) => mimetype.indexOf('image/') === 0)
+    .map((mimetype) => `data:${mimetype};base64,${output.data[mimetype]}`)
+
   return (
-    <blockquote style={style} className={`${outputTypeClassName}`}>
-      {hideLabel ? null :(
+    <blockquote className={`${outputTypeClassName}`}>
+      {hideLabel ? null : (
         <div>
           <div className="label">{t(outputTypeClassName)}</div>
         </div>
       )}
       {output.output_type === 'error' && (
-        <pre
-          style={{whiteSpace: 'pre-wrap'}}
-          className=" hljs d-block bg-dark text-white"
-        >
-          {JSON.stringify(output, null, 2)} 
+        <pre style={{ whiteSpace: 'pre-wrap' }} className=" hljs d-block bg-dark text-white">
+          {JSON.stringify(output, null, 2)}
         </pre>
       )}
       {output.output_type === 'stream' && (
         <details>
           <summary>...</summary>
-        <pre>{Array.isArray(output.text) ? output.text.join('') : output.text}</pre>
+          <pre>{Array.isArray(output.text) ? output.text.join('') : output.text}</pre>
         </details>
       )}
       {output.output_type === 'execute_result' && output.data['text/plain'] && (
@@ -71,15 +97,9 @@ const ArticleCellOutput = ({ output, height, width, hideLabel=false, isJavascrip
       {!hideLabel && output.output_type === 'display_data' && output.data['text/plain'] && (
         <pre>{getOutput(output.data['text/plain'])}</pre>
       )}
-      {!!output.data && !!output.data['image/gif'] && (
-        <img src={`data:image/gif;base64,${output.data['image/gif']}`} alt='display_data output'/>
-      )}
-      {!!output.data && !!output.data['image/png'] && (
-        <img src={`data:image/png;base64,${output.data['image/png']}`} alt='display_data output'/>
-      )}
-      {!!output.data && !!output.data['image/jpeg'] && (
-        <img src={`data:image/jpeg;base64,${output.data['image/jpeg']}`} alt='display_data output'/>
-      )}
+      {encodedImages.map((src, i) => (
+        <img key={i} style={style} src={src} alt="display_data output" />
+      ))}
     </blockquote>
   )
 }

--- a/src/components/Article/ArticleCellOutputs.js
+++ b/src/components/Article/ArticleCellOutputs.js
@@ -4,62 +4,74 @@ import { useInjectTrustedJavascript } from '../../hooks/graphics'
 
 const ArticleCellOutputs = ({
   isJavascriptTrusted,
-  outputs=[],
+  outputs = [],
   cellIdx,
   hideLabel,
+  height = 'auto',
 }) => {
   // use scripts if there areany
-  const trustedScripts =  isJavascriptTrusted ? outputs.reduce((acc, output) => {
-    if (typeof output.data === 'object') {
-      if (Array.isArray(output.data['application/javascript'])) {
-        return acc.concat(output.data['application/javascript'])
-      } else if(typeof output.data['application/javascript'] === 'string') {
-        // sometimes output.data['application/javascript'] is not an array...
-        return acc.concat([output.data['application/javascript']])
-      } else if (Array.isArray(output.data['text/html'])) {
-        // view if there are any candidate
+  const trustedScripts = isJavascriptTrusted
+    ? outputs.reduce((acc, output) => {
+        if (typeof output.data === 'object') {
+          if (Array.isArray(output.data['application/javascript'])) {
+            return acc.concat(output.data['application/javascript'])
+          } else if (typeof output.data['application/javascript'] === 'string') {
+            // sometimes output.data['application/javascript'] is not an array...
+            return acc.concat([output.data['application/javascript']])
+          } else if (Array.isArray(output.data['text/html'])) {
+            // view if there are any candidate
 
-        if (output.data['text/html'].some(d => d.indexOf('/script>') !== -1)) {
-          // we should alert somehow.
-          // eslint-disable-next-line
-          const htmlScript = output.data['text/html'].join('')
-            .match(/\x3Cscript[^>]*>([\s\S]*?)\x3C\/script>/m)
-          if (htmlScript) {
-            if (htmlScript[1].indexOf('\x3Cscript') !== -1) {
-              console.warn('multiple scripts in text/html, skipping.')
-              return acc
+            if (output.data['text/html'].some((d) => d.indexOf('/script>') !== -1)) {
+              // we should alert somehow.
+              // eslint-disable-next-line
+              const htmlScript = output.data['text/html']
+                .join('')
+                .match(/\x3Cscript[^>]*>([\s\S]*?)\x3C\/script>/m)
+              if (htmlScript) {
+                if (htmlScript[1].indexOf('\x3Cscript') !== -1) {
+                  console.warn('multiple scripts in text/html, skipping.')
+                  return acc
+                }
+                console.debug('[ArticleCellOutputs] cellIdx:', cellIdx, 'contains:', htmlScript[2])
+                return acc.concat(htmlScript[1])
+              }
             }
-            console.debug('[ArticleCellOutputs] cellIdx:', cellIdx, 'contains:', htmlScript[2])
-            return acc.concat(htmlScript[1])
+            // // eslint-disable-next-line
+            // debugger
+            // output.data['text/html'].match('\x3Cscript')
           }
         }
-        // // eslint-disable-next-line
-        // debugger
-        // output.data['text/html'].match('\x3Cscript')
-      }
-    }
-    return acc
-  }, []): []
+        return acc
+      }, [])
+    : []
 
   const refTrustedJavascript = useInjectTrustedJavascript({
     id: `trusted-script-for-${cellIdx}`,
     contents: trustedScripts,
-    isTrusted: isJavascriptTrusted
+    isTrusted: isJavascriptTrusted,
   })
 
   if (trustedScripts.length) {
-    console.debug('[ArticleCellOutputs] cellidx:',cellIdx,' - isJavascriptTrusted:', isJavascriptTrusted, '- n. script(s) to inject:', trustedScripts.length)
+    console.debug(
+      '[ArticleCellOutputs] cellidx:',
+      cellIdx,
+      ' - isJavascriptTrusted:',
+      isJavascriptTrusted,
+      '- n. script(s) to inject:',
+      trustedScripts.length,
+    )
   }
 
   return (
     <div className="ArticleCellOutputs" ref={refTrustedJavascript}>
-      {outputs.map((output,i) => (
+      {outputs.map((output, i) => (
         <ArticleCellOutput
           hideLabel={hideLabel}
           isJavascriptTrusted={false}
           cellIdx={cellIdx}
           output={output}
           key={i}
+          height={height}
         />
       ))}
     </div>

--- a/src/components/ArticleV2/ArticleLayer.js
+++ b/src/components/ArticleV2/ArticleLayer.js
@@ -4,19 +4,18 @@ import ArticleCell from '../Article/ArticleCell'
 import ArticleCellObserver from './ArticleCellObserver'
 import ArticleCellPlaceholder from './ArticleCellPlaceholder'
 import ArticleCellPopup from './ArticleCellPopup'
-import {a, useSpring, config} from 'react-spring'
+import { a, useSpring, config } from 'react-spring'
 import { useRefWithCallback } from '../../hooks/graphics'
 import { Button } from 'react-bootstrap'
 import { ArrowRight, ArrowLeft } from 'react-feather'
 import {
   DisplayLayerSectionBibliography,
   DisplayLayerSectionFooter,
-  IsMobile
+  IsMobile,
 } from '../../constants'
 import '../../styles/components/Article2/ArticleLayer.scss'
 
-
-function getCellAnchorFromIdx(idx, prefix='c') {
+function getCellAnchorFromIdx(idx, prefix = 'c') {
   return `${prefix}${idx}`
 }
 
@@ -25,36 +24,37 @@ function layerTransition(x, y, width, height) {
 }
 
 const ArticleLayer = ({
-  memoid='',
-  layer=LayerNarrative,
+  memoid = '',
+  layer = LayerNarrative,
   // previousLayer=null,
   // nextLayer=null,
-  paragraphsGroups=[],
-  paragraphs=[],
+  paragraphsGroups = [],
+  paragraphs = [],
   // index of selected cell  (cell.idx)
-  selectedCellIdx=-1,
-  selectedCellTop=0,
-  selectedLayerHeight=-1,
+  selectedCellIdx = -1,
+  selectedCellTop = 0,
+  selectedLayerHeight = -1,
   onDataHrefClick,
   onCellPlaceholderClick,
   onCellIntersectionChange,
   onAnchorClick,
-  isSelected=false,
-  selectedLayer='',
-  previousLayer='',
-  selectedSection=null,
-  previousCellIdx=-1,
-  layers=[],
+  isSelected = false,
+  selectedLayer = '',
+  previousLayer = '',
+  selectedSection = null,
+  previousCellIdx = -1,
+  layers = [],
   children,
-  width=0, height=0,
-  isJavascriptTrusted=false,
+  width = 0,
+  height = 0,
+  isJavascriptTrusted = false,
   style,
   // if it is defined, will override the style of the
   // ArticleLayout pushFixed header
   pageBackgroundColor,
-  renderedBibliographyComponent=null,
-  renderedFooterComponent=null,
-  renderedLogoComponent=null
+  renderedBibliographyComponent = null,
+  renderedFooterComponent = null,
+  renderedLogoComponent = null,
 }) => {
   const [popupProps, setPopupProps] = useSpring(() => ({
     x: 0,
@@ -62,29 +62,36 @@ const ArticleLayer = ({
     opacity: 0,
     cellIdx: -1,
     cellLayer: '',
-    config: config.stiff
+    config: config.stiff,
   }))
   const [mask, setMask] = useSpring(() => ({
-    clipPath: [width, 0, width, height], x:0, y:0,
-    config: config.slow
+    clipPath: [width, 0, width, height],
+    x: 0,
+    y: 0,
+    config: config.slow,
   }))
   const layerRef = useRefWithCallback((layerDiv) => {
     if (selectedSection) {
-      console.info('[ArticleLayer] @useRefWithCallback on selectedSection selected:', selectedSection)
+      console.info(
+        '[ArticleLayer] @useRefWithCallback on selectedSection selected:',
+        selectedSection,
+      )
       // get section offset
       const sectionElement = document.getElementById(getCellAnchorFromIdx(selectedSection, layer))
       if (!sectionElement) {
-        console.warn('[ArticleLayer] @useRefWithCallback could not find any sectionElement with given id:', selectedSection)
+        console.warn(
+          '[ArticleLayer] @useRefWithCallback could not find any sectionElement with given id:',
+          selectedSection,
+        )
         return
       }
       layerDiv.scrollTo({
         top: sectionElement.offsetTop + layerDiv.offsetTop - 150,
-        behavior: previousLayer === selectedLayer
-          ? 'smooth'
-          : 'instant'
+        behavior: previousLayer === selectedLayer ? 'smooth' : 'instant',
       })
       return
-    } else if (!isSelected || selectedCellIdx === -1) { // discard
+    } else if (!isSelected || selectedCellIdx === -1) {
+      // discard
       return
     }
     // get cellEmeemnt in current layer (as it can be just a placeholder,too)
@@ -95,22 +102,31 @@ const ArticleLayer = ({
     }
     // if the current layer height is greater than the height ref in the URL params,
     // it means we can safely scroll to the selectedcellTop position displayed in the URL.
-    const cellElementRefTop = height >= selectedLayerHeight
-      ? selectedCellTop
-      : selectedLayerHeight/2
+    const cellElementRefTop =
+      height >= selectedLayerHeight ? selectedCellTop : selectedLayerHeight / 2
     const top = cellElement.offsetTop + layerDiv.offsetTop - cellElementRefTop
     console.debug(
       '[ArticleLayer] useRefWithCallback',
-      '\n selectedCellIdx:', selectedCellIdx,
-      '\n layer', layer,
-      '\n scrollTo:', top
-    )
-    layerDiv.scrollTo({
+      '\n selectedCellIdx:',
+      selectedCellIdx,
+      '\n layer',
+      layer,
+      '\n scrollTo:',
       top,
-      behavior: !previousLayer || previousLayer === selectedLayer
-        ? 'smooth'
-        : 'instant'
-    })
+    )
+    setTimeout(() => {
+      const top = cellElement.offsetTop + layerDiv.offsetTop - cellElementRefTop
+
+      layerDiv.scrollTo({
+        top,
+        behavior: !previousLayer || previousLayer === selectedLayer ? 'smooth' : 'instant',
+      })
+    }, 10)
+    // layerDiv.scrollTo({
+    //   top,
+    //   behavior: !previousLayer || previousLayer === selectedLayer ? 'smooth' : 'instant',
+    // })
+    // cellElement.scrollIntoView()
   })
 
   const onCellPlaceholderClickHandler = (e, cell) => {
@@ -122,7 +138,7 @@ const ArticleLayer = ({
         previousIdx: cell.idx,
         previousLayer: layer,
         height, // ref height
-        y: wrapper.offsetTop - wrapper.parentNode.scrollTop - 15
+        y: wrapper.offsetTop - wrapper.parentNode.scrollTop - 15,
       })
     } else {
       console.warn('[ArticleLayer] misses a onCellPlaceholderClick listener')
@@ -143,7 +159,12 @@ const ArticleLayer = ({
         layer: previousLayer,
         idx: previousCellIdx > -1 ? previousCellIdx : cell.idx,
         height, // ref height
-        y: previousCellIdx > -1 ? selectedCellTop : e.currentTarget.parentNode.parentNode.offsetTop - e.currentTarget.parentNode.parentNode.parentNode.scrollTop - 15
+        y:
+          previousCellIdx > -1
+            ? selectedCellTop
+            : e.currentTarget.parentNode.parentNode.offsetTop -
+              e.currentTarget.parentNode.parentNode.parentNode.scrollTop -
+              15,
       })
     }
   }
@@ -153,23 +174,23 @@ const ArticleLayer = ({
    * update the Animatable properties of ArticleCellPopup component. We add there also
    * the current cell idx and cell layer (yes, it should be better placed in a ref @todo)
    */
-  const onNumClickHandler = (e, cell) =>  {
+  const onNumClickHandler = (e, cell) => {
     const wrapper = e.currentTarget.closest('.ArticleLayer_paragraphWrapper')
     setPopupProps.start({
       from: {
         x: e.currentTarget.parentNode.offsetLeft,
         y: wrapper.offsetTop,
-        opacity:.6,
+        opacity: 0.6,
         cellIdx: cell.idx,
         cellLayer: cell.layer,
       },
-      to:{
+      to: {
         x: e.currentTarget.parentNode.offsetLeft,
         y: wrapper.offsetTop - 10,
-        opacity:1,
+        opacity: 1,
         cellIdx: cell.idx,
-        cellLayer: cell.layer
-      }
+        cellLayer: cell.layer,
+      },
     })
     onAnchorClick(e, {
       layer: cell.layer,
@@ -177,7 +198,7 @@ const ArticleLayer = ({
       previousLayer: cell.layer,
       previousIdx: cell.idx,
       height, // ref height
-      y: wrapper.offsetTop - wrapper.parentNode.scrollTop - 15
+      y: wrapper.offsetTop - wrapper.parentNode.scrollTop - 15,
     })
   }
 
@@ -191,7 +212,7 @@ const ArticleLayer = ({
       height, // ref height
       y: wrapper.offsetTop - wrapper.parentNode.scrollTop - 15,
       previousLayer: selectedLayer,
-      previousIdx: cell.idx
+      previousIdx: cell.idx,
     })
   }
 
@@ -201,7 +222,7 @@ const ArticleLayer = ({
       layer: cell.layer,
       idx: cell.idx,
       height, // ref height
-      y: 100
+      y: 100,
     })
   }
 
@@ -219,25 +240,34 @@ const ArticleLayer = ({
       } else if (e.target.hasAttribute('data-idx')) {
         e.preventDefault()
         const targetCellIdx = parseInt(e.target.getAttribute('data-idx'), 10)
-        const targetCell = paragraphs.find(p => p.idx === targetCellIdx)
-        const cellElement = document.getElementById(getCellAnchorFromIdx(targetCellIdx, targetCell.layer))
+        const targetCell = paragraphs.find((p) => p.idx === targetCellIdx)
+        const cellElement = document.getElementById(
+          getCellAnchorFromIdx(targetCellIdx, targetCell.layer),
+        )
         if (!cellElement) {
           console.warn('Not found! celleElment with given id:', selectedCellIdx)
           return
         }
         // get cell idx where the event was generated.
         const wrapper = e.target.closest('.ArticleLayer_paragraphWrapper')
-        if (!wrapper){
+        if (!wrapper) {
           // nothing to do :(
-          console.warn('ArticleLayer_paragraphWrapper Not found! Element is maybe a placeholder.', selectedCellIdx)
+          console.warn(
+            'ArticleLayer_paragraphWrapper Not found! Element is maybe a placeholder.',
+            selectedCellIdx,
+          )
           return
         }
         const sourceCellidx = parseInt(wrapper.getAttribute('data-cell-idx'), 10)
         const sourceCellLayer = wrapper.getAttribute('data-cell-layer')
         console.debug(
           '[ArticleLayer] @onLayerClickHandler:',
-          '\n - target:', targetCellIdx, targetCell.layer,
-          '\n - source:', sourceCellidx, sourceCellLayer
+          '\n - target:',
+          targetCellIdx,
+          targetCell.layer,
+          '\n - source:',
+          sourceCellidx,
+          sourceCellLayer,
         )
         onAnchorClick(e, {
           layer: targetCell.layer,
@@ -245,7 +275,7 @@ const ArticleLayer = ({
           previousIdx: sourceCellidx,
           previousLayer: sourceCellLayer,
           height, // ref height
-          y: wrapper.offsetTop - wrapper.parentNode.scrollTop - 15
+          y: wrapper.offsetTop - wrapper.parentNode.scrollTop - 15,
         })
       }
     } else {
@@ -254,7 +284,7 @@ const ArticleLayer = ({
 
     if (!e.target.classList.contains('ArticleCellContent_num')) {
       setPopupProps.start({
-        opacity: 0
+        opacity: 0,
       })
     }
   }
@@ -262,28 +292,46 @@ const ArticleLayer = ({
   useEffect(() => {
     const layerLevel = layers.indexOf(layer)
     if (layerLevel === 0) {
-      setMask.set({ clipPath: [0, 0, width, height], x:-width, y:0 })
+      setMask.set({ clipPath: [0, 0, width, height], x: -width, y: 0 })
     } else if (layerLevel <= layers.indexOf(selectedLayer)) {
-      console.debug('[ArticleLayer] @useEffect open', layer, layers.indexOf(selectedLayer), layerLevel)
-      setMask.start({ clipPath: [0, 0, width, height], x:-width, y:0 })
+      console.debug(
+        '[ArticleLayer] @useEffect open',
+        layer,
+        layers.indexOf(selectedLayer),
+        layerLevel,
+      )
+      setMask.start({ clipPath: [0, 0, width, height], x: -width, y: 0 })
     } else if (layerLevel > layers.indexOf(selectedLayer)) {
-      console.debug('[ArticleLayer] @useEffect close', layer, layers.indexOf(selectedLayer), layerLevel)
-      setMask.start({ clipPath: [width, 0, width, height], x:0, y:0 })
+      console.debug(
+        '[ArticleLayer] @useEffect close',
+        layer,
+        layers.indexOf(selectedLayer),
+        layerLevel,
+      )
+      setMask.start({ clipPath: [width, 0, width, height], x: 0, y: 0 })
     }
   }, [isSelected, layer, layers])
 
-  console.debug('[ArticleLayer] rendered: ',layer,'- n. groups:', paragraphsGroups.length)
+  console.debug('[ArticleLayer] rendered: ', layer, '- n. groups:', paragraphsGroups.length)
 
   return (
-    <a.div ref={layerRef} className={`text-old-${layer} ArticleLayer_mask ${layer}`} style={{
-      ...style,
-      clipPath: mask.clipPath.to(layerTransition),
-    }} onClick={onLayerClickHandler}>
-      <div className={`ArticleLayer_pushFixed ${layer}`} style={{
-        backgroundColor: pageBackgroundColor,
-        height: IsMobile ? 0: 100
-      }}></div>
-      <ArticleCellPopup style={popupProps} onClick={onCellPopupClickHandler}/>
+    <a.div
+      ref={layerRef}
+      className={`text-old-${layer} ArticleLayer_mask ${layer}`}
+      style={{
+        ...style,
+        clipPath: mask.clipPath.to(layerTransition),
+      }}
+      onClick={onLayerClickHandler}
+    >
+      <div
+        className={`ArticleLayer_pushFixed ${layer}`}
+        style={{
+          backgroundColor: pageBackgroundColor,
+          height: IsMobile ? 0 : 100,
+        }}
+      ></div>
+      <ArticleCellPopup style={popupProps} onClick={onCellPopupClickHandler} />
       {renderedLogoComponent}
 
       {children}
@@ -295,15 +343,25 @@ const ArticleLayer = ({
           return (
             <React.Fragment key={i}>
               {paragraphsIndices.map((k) => (
-                <a key={['a', k].join('-')} className="ArticleLayer_anchor" id={getCellAnchorFromIdx(paragraphs[k].idx, layer)}></a>
+                <a
+                  key={['a', k].join('-')}
+                  className="ArticleLayer_anchor"
+                  id={getCellAnchorFromIdx(paragraphs[k].idx, layer)}
+                ></a>
               ))}
-              <div className={`ArticleLayer_placeholderWrapper position-relative ArticleLayer_placeholder ${layer}_${firstCellInGroup.layer}`}>
-                <div className={`ArticleLayer_placeholderActive ${layer} ${firstCellInGroup.idx ===  selectedCellIdx? 'on' : 'off'}`}/>
-                {paragraphsIndices.slice(0,2).map((j) => (
+              <div
+                className={`ArticleLayer_placeholderWrapper position-relative ArticleLayer_placeholder ${layer}_${firstCellInGroup.layer}`}
+              >
+                <div
+                  className={`ArticleLayer_placeholderActive ${layer} ${
+                    firstCellInGroup.idx === selectedCellIdx ? 'on' : 'off'
+                  }`}
+                />
+                {paragraphsIndices.slice(0, 2).map((j) => (
                   <ArticleCellObserver
                     onCellIntersectionChange={onCellIntersectionChange}
                     cell={paragraphs[j]}
-                    key={[i,j].join('-')}
+                    key={[i, j].join('-')}
                     className="ArticleStream_paragraph"
                   >
                     <ArticleCellPlaceholder
@@ -311,79 +369,104 @@ const ArticleLayer = ({
                       memoid={memoid}
                       {...paragraphs[j]}
                       headingLevel={paragraphs[j].isHeading ? paragraphs[j].heading.level : 0}
-                      nums={firstCellInGroup.idx !== paragraphs[j].idx ? [] : paragraphsIndices.map(d => paragraphs[d].num)}
+                      nums={
+                        firstCellInGroup.idx !== paragraphs[j].idx
+                          ? []
+                          : paragraphsIndices.map((d) => paragraphs[d].num)
+                      }
                     />
                   </ArticleCellObserver>
                 ))}
-                <div className={`ArticleLayer_placeholderGradient ${layer}_${firstCellInGroup.layer}`} />
+                <div
+                  className={`ArticleLayer_placeholderGradient ${layer}_${firstCellInGroup.layer}`}
+                />
                 <div className="ArticleLayer_placeholderButton">
-                  <Button variant="outline-secondary" size="sm" className="d-flex align-items-center" onClick={(e) => onCellPlaceholderClickHandler(e, firstCellInGroup)}>
-                    read in {firstCellInGroup.layer} layer
-                    &nbsp;
-                    <ArrowRight size={12}/>
+                  <Button
+                    variant="outline-secondary"
+                    size="sm"
+                    className="d-flex align-items-center"
+                    onClick={(e) => onCellPlaceholderClickHandler(e, firstCellInGroup)}
+                  >
+                    read in {firstCellInGroup.layer} layer &nbsp;
+                    <ArrowRight size={12} />
                   </Button>
                 </div>
-            </div>
+              </div>
             </React.Fragment>
           )
         }
 
         return (
           <React.Fragment key={i}>
-          {paragraphsIndices.map((j) => {
-            const cell = paragraphs[j]
-            if(!cell) {
-              // eslint-disable-next-line
-              debugger
-            }
-            return (
-              <React.Fragment  key={[i,j].join('-')}>
-              <a className="ArticleLayer_anchor" id={getCellAnchorFromIdx(cell.idx,layer)}></a>
-              <div
-                className="ArticleLayer_paragraphWrapper"
-                data-cell-idx={cell.idx}
-                data-cell-layer={cell.layer}
-              >
-                <div className={`ArticleLayer_cellActive ${firstCellInGroup.idx === selectedCellIdx || cell.idx === selectedCellIdx ? 'on' : 'off'}`} />
-                <ArticleCellObserver
-                  onCellIntersectionChange={onCellIntersectionChange}
-                  cell={cell}
-                  className="ArticleStream_paragraph"
-                >
-                  { cell.idx === selectedCellIdx && previousLayer !== '' && previousLayer !== layer && (
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      className="ArticleLayer_paragraphWrapper_backBtn"
-                      onClick={(e) => onSelectedCellClickHandler(e, cell)}
+            {paragraphsIndices.map((j) => {
+              const cell = paragraphs[j]
+              if (!cell) {
+                // eslint-disable-next-line
+                debugger
+              }
+              return (
+                <React.Fragment key={[i, j].join('-')}>
+                  <a className="ArticleLayer_anchor" id={getCellAnchorFromIdx(cell.idx, layer)}></a>
+                  <div
+                    className="ArticleLayer_paragraphWrapper"
+                    data-cell-idx={cell.idx}
+                    data-cell-layer={cell.layer}
+                  >
+                    <div
+                      className={`ArticleLayer_cellActive ${
+                        firstCellInGroup.idx === selectedCellIdx || cell.idx === selectedCellIdx
+                          ? 'on'
+                          : 'off'
+                      }`}
+                    />
+                    <ArticleCellObserver
+                      onCellIntersectionChange={onCellIntersectionChange}
+                      cell={cell}
+                      className="ArticleStream_paragraph"
                     >
-                      <ArrowLeft size={16} /> back
-                    </Button>
-                  )}
-                  <ArticleCell
-                    isJavascriptTrusted={isJavascriptTrusted}
-                    onNumClick={onNumClickHandler}
-                    memoid={memoid}
-                    {...cell}
-                    num={cell.num}
-                    idx={cell.idx}
-                    role={cell.role}
-                    layer={cell.layer}
-                    headingLevel={cell.isHeading ? cell.heading.level : 0}
-                  />
-                </ArticleCellObserver>
-              </div>
-              </React.Fragment>
-            )
-          })}
+                      {cell.idx === selectedCellIdx &&
+                        previousLayer !== '' &&
+                        previousLayer !== layer && (
+                          <Button
+                            size="sm"
+                            variant="secondary"
+                            className="ArticleLayer_paragraphWrapper_backBtn"
+                            onClick={(e) => onSelectedCellClickHandler(e, cell)}
+                          >
+                            <ArrowLeft size={16} /> back
+                          </Button>
+                        )}
+                      <ArticleCell
+                        isJavascriptTrusted={isJavascriptTrusted}
+                        onNumClick={onNumClickHandler}
+                        memoid={memoid}
+                        {...cell}
+                        num={cell.num}
+                        idx={cell.idx}
+                        role={cell.role}
+                        layer={cell.layer}
+                        headingLevel={cell.isHeading ? cell.heading.level : 0}
+                        windowHeight={height}
+                      />
+                    </ArticleCellObserver>
+                  </div>
+                </React.Fragment>
+              )
+            })}
           </React.Fragment>
         )
       })}
       <div className="ArticleLayer_push"></div>
-      <a className='ArticleLayer_anchor' id={getCellAnchorFromIdx(DisplayLayerSectionBibliography,layer)}></a>
+      <a
+        className="ArticleLayer_anchor"
+        id={getCellAnchorFromIdx(DisplayLayerSectionBibliography, layer)}
+      ></a>
       {renderedBibliographyComponent}
       <div className="my-5" />
-      <a className='ArticleLayer_anchor' id={getCellAnchorFromIdx(DisplayLayerSectionFooter,layer)}></a>
+      <a
+        className="ArticleLayer_anchor"
+        id={getCellAnchorFromIdx(DisplayLayerSectionFooter, layer)}
+      ></a>
       {renderedFooterComponent}
     </a.div>
   )

--- a/src/styles/components/Article/ArticleCellFigure.scss
+++ b/src/styles/components/Article/ArticleCellFigure.scss
@@ -1,0 +1,10 @@
+.ArticleCellFigure.with-aspect-ratio figure {
+  position: relative;
+  overflow: 'hidden';
+  height: 0;
+
+  .ArticleCellOutputs {
+    position: absolute;
+    top: 0;
+  }
+}


### PR DESCRIPTION
This PR aims at fixing the scrollintoView bug when dynamic content is present.
Scenario: user click on the ToC or click to on one cell in the article fingerprint vis to reach a specific paragraph in the article. If there is dynamically added content above the desired paragraph, like images and javascript powered datavis, the scrollIntoView() method does not work, as it would align to the wrong position. 

**Solution**
I've added a rule of thumb of 50% window height to each Figure in the article and the possibility of setting the aspect ratio or the height in px directly from cell tags (more details below in a comment of this PR). 

For **dynamic content** this fixed height is applied as `minHeight` to avoid the presence of a scrollbar, then there's basically no difference from what we got before. In most cases, those scripts set a fixed height themselves that they more or less respect (with the annoying message "bokeh is loaded." that add random vertical height to the box); in other cases, the .5% of window height  is enough to make the desired paragraph visible on the page.
Instead, for **images**. The result is this below, with floating images in the middle of the fixed height box (in grey, just to make it visible here):
<img width="500" alt="Screenshot 2022-11-14 at 11 51 44" src="https://user-images.githubusercontent.com/1181642/201642003-bc1075d5-b739-49f8-938b-dd36e3f01491.png">



