### PR TITLE
#51-pm: hotfix for cookie banner

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,14 +23,12 @@ import Loading from './pages/Loading'
 import { AppRoutes } from './routes'
 import { useStore } from './store'
 
-const AcceptAnalyticsCookies = useStore.getState().acceptAnalyticsCookies
+// const AcceptAnalyticsCookies = useStore.getState().acceptAnalyticsCookies
 const AcceptThirdPartyCookies = useStore.getState().acceptThirdPartyCookies
-const AcceptCookies = useStore.getState().acceptCookies
 
 console.info('\n   _   _ _   \n  | |_| | |_ \n  | | . |   |\n _| |___|_|_|\n|___|       \n\n')
 // console.info('%cacceptAnalyticsCookies', 'font-weight: bold', AcceptAnalyticsCookies)
 console.info('%cacceptThirdPartyCookies', 'font-weight: bold', AcceptThirdPartyCookies)
-// console.info('%cacceptCookies', 'font-weight: bold', AcceptCookies)
 
 // check if there CRFS cookie
 const csrfToken = new UniversalCookie().get('csrftoken')
@@ -62,7 +60,7 @@ export default function App() {
             <PercentLoader />
             <Header availableLanguages={LANGUAGES} isAuthDisabled />
             {typeof csrfToken === 'string' && <Me />}
-            <Cookies defaultAcceptCookies={AcceptCookies} />
+            <Cookies />
             {/* Hypothes.is integration */}
             <CanonicalUpdater />
             <main>

--- a/src/components/Cookies/Cookies.jsx
+++ b/src/components/Cookies/Cookies.jsx
@@ -7,7 +7,7 @@ import { useStore } from '../../store'
 import LangLink from '../LangLink'
 import styles from './Cookies.module.scss'
 
-const Cookies = ({ defaultAcceptCookies }) => {
+const Cookies = () => {
   const [isStoreReady, setStoreReady] = useState(false)
   const showCookieBanner = useStore((state) => state.showCookieBanner)
   const setAcceptThirdPartyCookies = useStore((state) => state.setAcceptThirdPartyCookies)
@@ -24,7 +24,7 @@ const Cookies = ({ defaultAcceptCookies }) => {
     setStoreReady(true)
   }, 2000)
 
-  if (defaultAcceptCookies || !isStoreReady) {
+  if (!isStoreReady) {
     return null
   }
   console.debug('[Cookies] \n - showCookieBanner:', showCookieBanner)

--- a/src/store.js
+++ b/src/store.js
@@ -109,7 +109,6 @@ export const useStore = create(
       backgroundColor: '#ffffff',
       acceptAnalyticsCookies: false,
       acceptThirdPartyCookies: false, // cookies should be accepted, session is stored locally
-      acceptCookies: false, // cookies should be accepted, session is stored locally
       showCookieBanner: true,
       releaseNotified: false,
       mode: 'dark', // or light
@@ -122,9 +121,6 @@ export const useStore = create(
           header.style.backgroundColor = backgroundColor
         }
         return set({ backgroundColor })
-      },
-      setAcceptCookies: () => {
-        set({ acceptCookies: true })
       },
       setShowCookieBanner: (value) => {
         set({ showCookieBanner: Boolean(value) })


### PR DESCRIPTION
The old AcceptCookies parameter from the store blocked the display of the banner.

Step to reproduce:

Set the value of acceptCookies to true in the local storage with the dev tools.

<img width="2660" height="1218" alt="image" src="https://github.com/user-attachments/assets/061812cf-f8f2-45e8-8a09-941058c4152f" />
